### PR TITLE
Add OrderUpdate document

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.1
+before_install:
+  - gem install bundler

--- a/lib/owd/documents/order_update.rb
+++ b/lib/owd/documents/order_update.rb
@@ -1,0 +1,20 @@
+module OWD
+  class OrderUpdate < Document
+    def _build opts = {}
+      doc.tag!(self.owd_name,
+              { clientOrderId:  opts[:order_reference] }) do
+
+        doc.SHIP_NAME             opts[:first_name]     if opts[:first_name]
+        doc.SHIP_COMPANY          opts[:company_name]   if opts[:company_name]
+        doc.SHIP_ADDRESS_ONE      opts[:address_one]    if opts[:address_one]
+        doc.SHIP_ADDRESS_TWO      opts[:address_two]    if opts[:address_two]
+        doc.SHIP_CITY             opts[:city]           if opts[:city]
+        doc.SHIP_STATE            opts[:state]          if opts[:state]
+        doc.SHIP_POSTCODE         opts[:zip]            if opts[:zip]
+        doc.SHIP_COUNTRY          opts[:country]        if opts[:country]
+        doc.SHIP_PHONE            opts[:phone]          if opts[:phone]
+        doc.SHIP_EMAIL            opts[:email]          if opts[:email]
+      end
+    end
+  end
+end

--- a/test/documents/test_order_update.rb
+++ b/test/documents/test_order_update.rb
@@ -1,0 +1,42 @@
+require 'owd/documents/order_update'
+require 'test_helper'
+
+describe OWD::OrderUpdate do
+  before do
+    @doc = OWD::OrderUpdate.new
+  end
+
+  describe '#owd_name' do
+    it { assert_equal @doc.owd_name, 'OWD_ORDER_UPDATE_REQUEST' }
+  end
+
+  describe '#build' do
+    it 'builds an XML body with an :order_reference' do
+      assert_equal_xml @doc.build(
+        order_reference: 123,
+        first_name: "Joe",
+        address_one: "300 Webster Street",
+        city: "Oakland",
+        state: "CA",
+        email: "email@gmail.com",
+        zip: "94607",
+        country: "US",
+        phone: "555-5555"
+      ), <<-XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <OWD_API_REQUEST>
+          <OWD_ORDER_UPDATE_REQUEST clientOrderId="123">
+            <SHIP_NAME>Joe</SHIP_NAME>
+            <SHIP_ADDRESS_ONE>300 Webster Street</SHIP_ADDRESS_ONE>
+            <SHIP_CITY>Oakland</SHIP_CITY>
+            <SHIP_STATE>CA</SHIP_STATE>
+            <SHIP_POSTCODE>94607</SHIP_POSTCODE>
+            <SHIP_COUNTRY>US</SHIP_COUNTRY>
+            <SHIP_PHONE>555-5555</SHIP_PHONE>
+            <SHIP_EMAIL>email@gmail.com</SHIP_EMAIL>
+          </OWD_ORDER_UPDATE_REQUEST>
+        </OWD_API_REQUEST>
+      XML
+    end
+  end
+end


### PR DESCRIPTION
Adds a document for updating an existing OWD order. Since we're only concerned with updating the order's address that's what I focused on & figured more info can be added to the call, as needed, later. If we'd like to go ahead and add everything now, that's cool too!

In terms of the travis.yml change: https://github.com/travis-ci/travis-ci/issues/3531
