### PR TITLE
Use Net::HTTP for timeout handling

### DIFF
--- a/lib/owd/error.rb
+++ b/lib/owd/error.rb
@@ -2,8 +2,8 @@ module OWD
   class APIError < StandardError
     attr_accessor :owd_error_type, :owd_error_message
     def initialize details = {}
-      self.owd_error_type    = details['type']
-      self.owd_error_message = details['message']
+      self.owd_error_type    = details.fetch('type', nil)
+      self.owd_error_message = details.fetch('message', nil)
       super("#{owd_error_type}: #{owd_error_message}")
     end
   end

--- a/lib/owd/request.rb
+++ b/lib/owd/request.rb
@@ -2,30 +2,44 @@ module OWD
   class Request
     ENDPOINT = 'https://secure.owd.com/webapps/api/api.jsp'
 
-    attr_reader :xml, :timeout_seconds
+    attr_reader :xml, :timeout_seconds, :uri
 
     def initialize(xml, timeout_seconds)
       @xml = xml
       @timeout_seconds = timeout_seconds.to_i
+      @uri = URI.parse(ENDPOINT)
     end
 
     def perform
-      uri = URI.parse(ENDPOINT)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = (uri.scheme == 'https')
-
-      request = Net::HTTP::Post.new(uri.request_uri)
-      request.body = xml
-      request["Content-Type"] = "text/xml"
-
-      Timeout::timeout(timeout_seconds) {
-        parse_response(http.request(request))
-      }
+      parse_response
+    rescue Net::OpenTimeout
+      raise APIError.new({
+        'type' => 'Timeout',
+        'message' => 'Request timed out'})
     end
 
     private
 
-    def parse_response(response)
+    def client
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == 'https')
+      http.open_timeout = timeout_seconds
+      http.read_timeout = timeout_seconds
+      http
+    end
+
+    def request_parameters
+      request = Net::HTTP::Post.new(uri.request_uri)
+      request.body = xml
+      request["Content-Type"] = "text/xml"
+      request
+    end
+
+    def response
+      @response ||= client.request(request_parameters)
+    end
+
+    def parse_response
       Crack::XML.parse(response.body)['OWD_API_RESPONSE'].tap do |results|
         if results['results'] == 'ERROR'
           raise APIError.new 'type'    => results['error_type'],

--- a/lib/owd/request.rb
+++ b/lib/owd/request.rb
@@ -31,6 +31,9 @@ module OWD
 
     def request_parameters
       request = Net::HTTP::Post.new(uri.request_uri)
+      request.open_timeout = timeout_seconds
+      request.read_timeout = timeout_seconds
+      request.ssl_timeout = timeout_seconds
       request.body = xml
       request["Content-Type"] = "text/xml"
       request

--- a/lib/owd/request.rb
+++ b/lib/owd/request.rb
@@ -25,6 +25,7 @@ module OWD
       http.use_ssl = (uri.scheme == 'https')
       http.open_timeout = timeout_seconds
       http.read_timeout = timeout_seconds
+      http.ssl_timeout = timeout_seconds
       http
     end
 

--- a/test/test_request.rb
+++ b/test/test_request.rb
@@ -1,0 +1,26 @@
+require "./test/test_helper"
+
+describe OWD::Request do
+  before do
+    @request = OWD::Request.new(api_request_xml, 15)
+  end
+
+  it 'returns an API error on timeout' do
+    raises_exception = -> { raise Net::OpenTimeout }
+    @request.stub :parse_response, raises_exception do
+      assert_raises(OWD::APIError) { @request.perform }
+    end
+  end
+
+  def api_request_xml
+    <<-xml
+      <OWD_API_REQUEST api_version='1.0' client_authorization='abc123' client_id='123' testing='FALSE'>
+         <OWD_TEST_INVENTORY_SETCOUNT_REQUEST>
+           <SKU>BPC-GU-MLBUNIV</SKU>
+           <TYPE>ADJUST</TYPE>
+           <VALUE>1</VALUE>
+         </OWD_TEST_INVENTORY_SETCOUNT_REQUEST>
+       </OWD_API_REQUEST>
+    xml
+  end
+end


### PR DESCRIPTION
There are known issues with the [Ruby](http://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/) [timeout](http://jvns.ca/blog/2015/11/27/why-rubys-timeout-is-dangerous-and-thread-dot-raise-is-terrifying/) [library](https://coderwall.com/p/1novga/ruby-timeouts-are-dangerous). This change uses the Net::HTTP library to handle timeouts.
