### PR TITLE
Global configuration, update with line items, switch endpoint based on environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /Gemfile.lock
 /*.gem
 tags
+.ruby-gemset
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rvm:
   - 2.2.1
 before_install:
   - gem install bundler
+script:
+  - bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -4,8 +4,25 @@
 
 The owd gem is a simple client for One World Direct's XML API.
 
+## Configuration
+
+app/config/initializers/owd.rb
 ```ruby
-client = OWD::Client.new(:client_id => 123, :client_authorization => 'XXXXXXXXXX')
+yaml = YAML.load_file(Rails.root.join('config', 'owd.yml'))[Rails.env]
+
+OWD.configure do |c|
+  c.client_id = yaml['client_id']
+  c.client_authorization = yaml['client_authorization']
+  c.testing = yaml['testing']
+  c.environment = yaml['environment']
+end
+
+```
+
+or initialize the client directly
+
+```ruby
+client = OWD::Client.new(:client_id => 123, :client_authorization => 'XXXXXXXXXX', :environment => 'production')
 client.api.inventory_create(:sku => 'MY-FANCY-SKU')
 client.api.order_status({ order_reference: 666 })
 ```
@@ -14,6 +31,95 @@ client.api.order_status({ order_reference: 666 })
 
 ```bash
 gem install owd
+```
+
+## Example Order Create
+```ruby
+params = {
+  order_reference: 'abcdef12345',
+  order_source: 'Web',
+  backorder_rule: 'PARTIALSHIP',
+  hold_for_release: 'NO',
+  shipping_info: {
+    company_name: 'Billy Bob',
+    address_one: '1234 Main Street',
+    address_two: 'Second Floor',
+    city: 'Santa Monica',
+    state: 'CA',
+    zip: '90401',
+    country: 'United States',
+    phone: '1113334444',
+    email: 'billy.bob@mail.com',
+    ship_type: 'FDX.GND',
+    insure_amount: '1.50',
+    declared_value: '1.00',
+    customs_desc: 'Customs description',
+    terms: 'SHIPPER'
+  },
+  billing_info: {
+    paid: 'YES',
+    payment_type: 'CLIENT'
+  },
+  line_items: [
+    part_reference: 'SKU',
+    description: 'Material name',
+    requested: 1,
+    cost: 1.50,
+    declared_value: 1.00,
+    customs_desc: 'Customs description for sku',
+    line_number: 'line-item-id',
+    is_insert_item: 'NO'
+  ]
+}
+client = OWD::Client.new
+response = client.api.order_create(params)
+```
+
+## Example Order Update
+```ruby
+params = {
+  order_reference: 'abcdef12345',
+  company_name: 'Billy Bob',
+  address_one: '1234 Main Street',
+  address_two: 'Second Floor',
+  city: 'Santa Monica',
+  state: 'CA',
+  zip: '90401',
+  country: 'United States',
+  phone: '1113334444',
+  email: 'billy.bob@mail.com',
+  line_items: [
+    part_reference: 'SKU',
+    description: 'Material name',
+    requested: 1,
+    cost: 1.50,
+    declared_value: 1.00,
+    customs_desc: 'Customs description for sku',
+    line_number: 'line-item-id',
+    is_insert_item: 'NO'
+  ]
+}
+
+client = OWD::Client.new
+response = client.api.order_update(params)
+```
+
+## Example Order Hold
+```ruby
+client = OWD::Client.new
+response = client.api.order_update(order_reference: 'abcdef12345')
+```
+
+## Example Order Release
+```ruby
+client = OWD::Client.new
+response = client.api.order_release(order_reference: 'abcdef12345')
+```
+
+## Example Order Status
+```ruby
+client = OWD::Client.new
+response = client.api.order_status(order_reference: 'abcdef12345')
 ```
 
 See OWD's website at http://www.owd.com

--- a/lib/owd.rb
+++ b/lib/owd.rb
@@ -2,3 +2,27 @@ libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
 require 'owd/base'
+
+module OWD
+  class Configuration
+    attr_accessor :client_id, :client_authorization, :testing, :environment
+
+    def initialize
+      @client_id = @client_authorization = 'xxx'
+      @environment = 'staging'
+      @testing = false
+    end
+  end
+
+  class << self
+    @@configuration ||= Configuration.new
+
+    def configuration
+      @@configuration
+    end
+
+    def configure
+      yield(configuration)
+    end
+  end
+end

--- a/lib/owd/client.rb
+++ b/lib/owd/client.rb
@@ -6,12 +6,14 @@ module OWD
   class Client
     API_VERSION = '1.9'
 
-    attr_reader :client_id, :client_authorization, :testing
+    attr_reader :client_id, :client_authorization, :testing, :environment
 
     def initialize opts = {}
-      @client_id            = opts[:client_id]
-      @client_authorization = opts[:client_authorization]
-      @testing              = opts[:testing] ? 'TRUE' : 'FALSE'
+      @client_id            = opts[:client_id].presence            || OWD.configuration.client_id
+      @client_authorization = opts[:client_authorization].presence || OWD.configuration.client_authorization
+      @environment          = opts[:environment]                   || OWD.configuration.environment
+      @testing              = opts[:testing]                       || OWD.configuration.testing
+      @testing              = @testing ? 'TRUE' : 'FALSE'
     end
 
     def api
@@ -32,7 +34,7 @@ module OWD
                          :client_id            => @client_id,
                          :client_authorization => @client_authorization,
                          :testing              => @testing).build(opts)
-      Request.new(xml).perform
+      Request.new(xml, @environment).perform
     end
 
     def symbol_to_class_name sym

--- a/lib/owd/documents/order_update.rb
+++ b/lib/owd/documents/order_update.rb
@@ -4,16 +4,32 @@ module OWD
       doc.tag!(self.owd_name,
               { clientOrderId:  opts[:order_reference] }) do
 
-        doc.SHIP_NAME             opts[:first_name]     if opts[:first_name]
-        doc.SHIP_COMPANY          opts[:company_name]   if opts[:company_name]
-        doc.SHIP_ADDRESS_ONE      opts[:address_one]    if opts[:address_one]
-        doc.SHIP_ADDRESS_TWO      opts[:address_two]    if opts[:address_two]
-        doc.SHIP_CITY             opts[:city]           if opts[:city]
-        doc.SHIP_STATE            opts[:state]          if opts[:state]
-        doc.SHIP_POSTCODE         opts[:zip]            if opts[:zip]
-        doc.SHIP_COUNTRY          opts[:country]        if opts[:country]
-        doc.SHIP_PHONE            opts[:phone]          if opts[:phone]
-        doc.SHIP_EMAIL            opts[:email]          if opts[:email]
+        if opts[:bill_to].present?
+          bill_opts = opts[:bill_to]
+          doc.BILL_NAME             bill_opts[:first_name]      if bill_opts[:first_name]
+          doc.BILL_COMPANY          bill_opts[:company_name]    if bill_opts[:company_name]
+          doc.BILL_ADDRESS_ONE      bill_opts[:address_one]     if bill_opts[:address_one]
+          doc.BILL_ADDRESS_TWO      bill_opts[:address_two]     if bill_opts[:address_two]
+          doc.BILL_CITY             bill_opts[:city]            if bill_opts[:city]
+          doc.BILL_STATE            bill_opts[:state]           if bill_opts[:state]
+          doc.BILL_POSTCODE         bill_opts[:zip]             if bill_opts[:zip]
+          doc.BILL_COUNTRY          bill_opts[:country]         if bill_opts[:country]
+          doc.BILL_PHONE            bill_opts[:phone]           if bill_opts[:phone]
+          doc.BILL_EMAIL            bill_opts[:email]           if bill_opts[:email]
+          doc.BILL_PO               bill_opts[:po]              if bill_opts[:po]
+        end
+
+        doc.SHIP_NAME             opts[:first_name]      if opts[:first_name]
+        doc.SHIP_COMPANY          opts[:company_name]    if opts[:company_name]
+        doc.SHIP_ADDRESS_ONE      opts[:address_one]     if opts[:address_one]
+        doc.SHIP_ADDRESS_TWO      opts[:address_two]     if opts[:address_two]
+        doc.SHIP_CITY             opts[:city]            if opts[:city]
+        doc.SHIP_STATE            opts[:state]           if opts[:state]
+        doc.SHIP_POSTCODE         opts[:zip]             if opts[:zip]
+        doc.SHIP_COUNTRY          opts[:country]         if opts[:country]
+        doc.SHIP_PHONE            opts[:phone]           if opts[:phone]
+        doc.SHIP_EMAIL            opts[:email]           if opts[:email]
+        doc.SHIPPING_METHOD       opts[:shipping_method] if opts[:shipping_method]
 
         doc.tag!(:LINE_ITEMS) do
           opts[:line_items].each do |line_item|

--- a/lib/owd/documents/order_update.rb
+++ b/lib/owd/documents/order_update.rb
@@ -14,6 +14,13 @@ module OWD
         doc.SHIP_COUNTRY          opts[:country]        if opts[:country]
         doc.SHIP_PHONE            opts[:phone]          if opts[:phone]
         doc.SHIP_EMAIL            opts[:email]          if opts[:email]
+
+        doc.tag!(:LINE_ITEMS) do
+          opts[:line_items].each do |line_item|
+            doc.LINE_ITEM line_item
+          end
+        end if opts[:line_items]
+
       end
     end
   end

--- a/lib/owd/request.rb
+++ b/lib/owd/request.rb
@@ -1,6 +1,6 @@
 module OWD
   class Request
-    ENDPOINT = 'https://secure.owd.com/webapps/api/api.jsp'
+    ENDPOINT = 'https://secure.owd.com/api/api.jsp'
     STAGING_ENDPOINT = 'https://secure.owd.com/test/api/api.jsp'
 
     attr_reader :xml, :environment

--- a/lib/owd/request.rb
+++ b/lib/owd/request.rb
@@ -1,23 +1,29 @@
 module OWD
   class Request
     ENDPOINT = 'https://secure.owd.com/webapps/api/api.jsp'
+    STAGING_ENDPOINT = 'https://secure.owd.com/test/api/api.jsp'
 
-    attr_reader :xml
+    attr_reader :xml, :environment
 
-    def initialize(xml)
+    def initialize(xml, environment = 'staging')
       @xml = xml
+      @environment = environment
     end
 
     def perform
-      uri = URI.parse(ENDPOINT)
+      uri = URI.parse(endpoint)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = (uri.scheme == 'https')
 
       request = Net::HTTP::Post.new(uri.request_uri)
       request.body = xml
-      request["Content-Type"] = "text/xml"
 
+      request["Content-Type"] = "text/xml"
       parse_response(http.request(request))
+    end
+
+    def endpoint
+      @endpoint ||= @environment == 'production' ? ENDPOINT : STAGING_ENDPOINT
     end
 
     private

--- a/test/documents/test_order_update.rb
+++ b/test/documents/test_order_update.rb
@@ -38,5 +38,46 @@ describe OWD::OrderUpdate do
         </OWD_API_REQUEST>
       XML
     end
+
+    it 'builds an XML body with line_items if present' do
+      assert_equal_xml @doc.build(
+        order_reference: 123,
+        first_name: "Joe",
+        address_one: "300 Webster Street",
+        city: "Oakland",
+        state: "CA",
+        email: "email@gmail.com",
+        zip: "94607",
+        country: "US",
+        phone: "555-5555",
+        line_items: [
+          part_reference: 'SKU',
+          description: 'Material Name',
+          requested: 11,
+          cost: '1.5',
+          declared_value: '1.0',
+          customs_desc: 'Customs description',
+          line_number: '123-line-item',
+          is_insert_item: 'NO'
+        ]
+      ), <<-XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <OWD_API_REQUEST>
+          <OWD_ORDER_UPDATE_REQUEST clientOrderId="123">
+            <SHIP_NAME>Joe</SHIP_NAME>
+            <SHIP_ADDRESS_ONE>300 Webster Street</SHIP_ADDRESS_ONE>
+            <SHIP_CITY>Oakland</SHIP_CITY>
+            <SHIP_STATE>CA</SHIP_STATE>
+            <SHIP_POSTCODE>94607</SHIP_POSTCODE>
+            <SHIP_COUNTRY>US</SHIP_COUNTRY>
+            <SHIP_PHONE>555-5555</SHIP_PHONE>
+            <SHIP_EMAIL>email@gmail.com</SHIP_EMAIL>
+            <LINE_ITEMS>
+              <LINE_ITEM part_reference="SKU" description="Material Name" requested="11" cost="1.5" declared_value="1.0" customs_desc="Customs description" line_number="123-line-item" is_insert_item="NO" />
+            </LINE_ITEMS>
+          </OWD_ORDER_UPDATE_REQUEST>
+        </OWD_API_REQUEST>
+      XML
+    end
   end
 end

--- a/test/documents/test_order_update.rb
+++ b/test/documents/test_order_update.rb
@@ -14,6 +14,7 @@ describe OWD::OrderUpdate do
     it 'builds an XML body with an :order_reference' do
       assert_equal_xml @doc.build(
         order_reference: 123,
+        shipping_method: 'FDX.STD',
         first_name: "Joe",
         address_one: "300 Webster Street",
         city: "Oakland",
@@ -26,6 +27,7 @@ describe OWD::OrderUpdate do
         <?xml version="1.0" encoding="UTF-8"?>
         <OWD_API_REQUEST>
           <OWD_ORDER_UPDATE_REQUEST clientOrderId="123">
+            <SHIPPING_METHOD>FDX.STD</SHIPPING_METHOD>
             <SHIP_NAME>Joe</SHIP_NAME>
             <SHIP_ADDRESS_ONE>300 Webster Street</SHIP_ADDRESS_ONE>
             <SHIP_CITY>Oakland</SHIP_CITY>
@@ -42,14 +44,6 @@ describe OWD::OrderUpdate do
     it 'builds an XML body with line_items if present' do
       assert_equal_xml @doc.build(
         order_reference: 123,
-        first_name: "Joe",
-        address_one: "300 Webster Street",
-        city: "Oakland",
-        state: "CA",
-        email: "email@gmail.com",
-        zip: "94607",
-        country: "US",
-        phone: "555-5555",
         line_items: [
           part_reference: 'SKU',
           description: 'Material Name',
@@ -64,14 +58,6 @@ describe OWD::OrderUpdate do
         <?xml version="1.0" encoding="UTF-8"?>
         <OWD_API_REQUEST>
           <OWD_ORDER_UPDATE_REQUEST clientOrderId="123">
-            <SHIP_NAME>Joe</SHIP_NAME>
-            <SHIP_ADDRESS_ONE>300 Webster Street</SHIP_ADDRESS_ONE>
-            <SHIP_CITY>Oakland</SHIP_CITY>
-            <SHIP_STATE>CA</SHIP_STATE>
-            <SHIP_POSTCODE>94607</SHIP_POSTCODE>
-            <SHIP_COUNTRY>US</SHIP_COUNTRY>
-            <SHIP_PHONE>555-5555</SHIP_PHONE>
-            <SHIP_EMAIL>email@gmail.com</SHIP_EMAIL>
             <LINE_ITEMS>
               <LINE_ITEM part_reference="SKU" description="Material Name" requested="11" cost="1.5" declared_value="1.0" customs_desc="Customs description" line_number="123-line-item" is_insert_item="NO" />
             </LINE_ITEMS>
@@ -79,5 +65,39 @@ describe OWD::OrderUpdate do
         </OWD_API_REQUEST>
       XML
     end
+
+    it 'builds an XML body with bill_to if present' do
+      assert_equal_xml @doc.build(
+        order_reference: 123,
+        bill_to: {
+          company_name: "Revolution",
+          first_name: "Joe",
+          address_one: "300 Webster Street",
+          city: "Oakland",
+          state: "CA",
+          email: "email@gmail.com",
+          zip: "94607",
+          country: "US",
+          phone: "555-5555"
+
+        }
+      ), <<-XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <OWD_API_REQUEST>
+          <OWD_ORDER_UPDATE_REQUEST clientOrderId="123">
+            <BILL_COMPANY>Revolution</BILL_COMPANY>
+            <BILL_NAME>Joe</BILL_NAME>
+            <BILL_ADDRESS_ONE>300 Webster Street</BILL_ADDRESS_ONE>
+            <BILL_CITY>Oakland</BILL_CITY>
+            <BILL_STATE>CA</BILL_STATE>
+            <BILL_POSTCODE>94607</BILL_POSTCODE>
+            <BILL_COUNTRY>US</BILL_COUNTRY>
+            <BILL_PHONE>555-5555</BILL_PHONE>
+            <BILL_EMAIL>email@gmail.com</BILL_EMAIL>
+          </OWD_ORDER_UPDATE_REQUEST>
+        </OWD_API_REQUEST>
+      XML
+    end
+
   end
 end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -5,7 +5,7 @@ describe OWD::Client do
     @client = OWD::Client.new(client_id: 123, client_authorization: 'abc')
   end
 
-  it 'gives acess to order_status' do
+  it 'gives access to order_status' do
     mock_order_status = MiniTest::Mock.new
     mock_order_status.expect(:build, '', [{foo: 'bar'}])
 

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -1,0 +1,37 @@
+require "./test/test_helper"
+
+describe OWD do
+  before do
+    OWD.configure do |config|
+      config.client_id = 123
+      config.client_authorization = 'abc'
+      config.testing = false
+      config.environment = 'production'
+    end
+  end
+
+  describe 'global configuration' do
+    it { assert_equal OWD.configuration.client_id, 123 }
+    it { assert_equal OWD.configuration.client_authorization, 'abc' }
+    it { assert_equal OWD.configuration.testing, false }
+    it { assert_equal OWD.configuration.environment, 'production' }
+  end
+
+  describe 'client' do
+    it 'will use global configuration if no credentials passed on initialize' do
+      client = OWD::Client.new
+      assert_equal client.client_id, 123
+      assert_equal client.client_authorization, 'abc'
+      assert_equal client.testing, 'FALSE'
+      assert_equal client.environment, 'production'
+    end
+
+    it 'will override global configuration if credentials passed on initialize' do
+      client = OWD::Client.new(client_id: 321, client_authorization: 'xyz', testing: true, environment: 'staging')
+      assert_equal client.client_id, 321
+      assert_equal client.client_authorization, 'xyz'
+      assert_equal client.testing, 'TRUE'
+      assert_equal client.environment, 'staging'
+    end
+  end
+end

--- a/test/test_request.rb
+++ b/test/test_request.rb
@@ -1,0 +1,17 @@
+require "./test/test_helper"
+
+describe OWD::Request do
+  describe 'endpoint' do
+    describe 'when environment == "production"' do
+      it 'return https://secure.owd.com/webapps/api/api.jsp' do
+        assert_equal OWD::Request.new('xml', 'production').endpoint, 'https://secure.owd.com/webapps/api/api.jsp'
+      end
+    end
+
+    describe 'when environment == "staging"' do
+      it 'returns https://secure.owd.com/test/api/api.jsp' do
+        assert_equal OWD::Request.new('xml', 'staging').endpoint, 'https://secure.owd.com/test/api/api.jsp'
+      end
+    end
+  end
+end

--- a/test/test_request.rb
+++ b/test/test_request.rb
@@ -3,8 +3,8 @@ require "./test/test_helper"
 describe OWD::Request do
   describe 'endpoint' do
     describe 'when environment == "production"' do
-      it 'return https://secure.owd.com/webapps/api/api.jsp' do
-        assert_equal OWD::Request.new('xml', 'production').endpoint, 'https://secure.owd.com/webapps/api/api.jsp'
+      it 'return https://secure.owd.com/api/api.jsp' do
+        assert_equal OWD::Request.new('xml', 'production').endpoint, 'https://secure.owd.com/api/api.jsp'
       end
     end
 


### PR DESCRIPTION
Hello.

So I have bundled a few changes in this pull request.

1. Global Configuration
Now you can set the client_id, client_authorization, testing, and (new) environment in an initializer. 
The newly added environment is required to determine which endpoint to hit.  If you want to hit the production API, set environment to 'production', otherwise set it to 'staging'.  Note that it is staging by default. 

2. Update Order
I added the ability to update the line_items of an order.  If you don't include a line_items array in the payload, it will work as before.

3. Environment Switching
OWD now has a staging environment.  They say they periodically purge / refresh their data, but I had to request they perform the refresh by opening a ticket.  Also, the first time I used it I got 503 http responses.  Only after I opened another ticket did they find that the staging app crashed.  As fragile as it may be, I am very happy to have a staging environment.  The gem will by default use the staging environment, so you MUST set the environment for your apps in production.

I added a few tests and we now run the tests with travis integration. 

Please feel free to push back on any thing you don't like.  I am happy to help with this project. 